### PR TITLE
📦 Configuration: Configuracion de Persistencia de sesión (Recordar mis credenciales)

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -22,6 +22,7 @@ class LoginController extends Controller
 
         $credenciales = $request->only('email', 'password');
 
+        //Mantiene al usuario autenticado incluso despues de cerrar el navegador
         if (Auth::attempt($credenciales, $request->filled('remember'))) {
             $request->session()->regenerate();
             $user = Auth::user();

--- a/config/session.php
+++ b/config/session.php
@@ -32,9 +32,11 @@ return [
     |
     */
 
-    'lifetime' => (int) env('SESSION_LIFETIME', 120),
+    //Tiempo de inactividad permitido en (Minutos) 2 horas
+    'lifetime' => 120, 
 
-    'expire_on_close' => env('SESSION_EXPIRE_ON_CLOSE', false),
+    //La sesion no se cerrara al cerrar el navegador (Siempre que haya marcado recordar mis credenciales de lo contrario, al cerrar el navegador se cerrara la sesión "Tendra que volver a iniciar sesión con las credenciales")
+    'expire_on_close' =>  true, 
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
configurar persistencia de sesión con opción 'Recordarme'" (Recordar mis credenciales).
Se configuró 'lifetime' y 'expire_on_close' en session.php para manejar sesiones activas. 
La sesione se cierra al cerrar el navegador si no se marca 'Recordar mis credenciales',  
La secion se cierra después de 120 min de inactividad  (Momentáneo se puede cambiar), esto si no marca "Recordar Mis credenciales",
La secion se mantienen activa al marcarla. incluso al cerrar el navegador"
